### PR TITLE
Update sample_nodejs_documentdb.js

### DIFF
--- a/samples/connect-and-query/sample_nodejs_documentdb.js
+++ b/samples/connect-and-query/sample_nodejs_documentdb.js
@@ -16,7 +16,7 @@ const assert = require('assert');
 var ca = [fs.readFileSync("rds-combined-ca-bundle.pem")];
 
 // Connection URL
-const connstring = `mongodb://${username}:${password}@${clusterendpoint}/sample-database?ssl=true&replicaSet=rs0&readPreference=secondaryPreferred`;
+const connstring = `mongodb://${username}:${password}@${clusterendpoint}/sample-database?ssl=true&replicaSet=rs0&readPreference=secondaryPreferred&retryWrites=false`;
 
 // Database Name
 const dbName = 'myproject';


### PR DESCRIPTION
While testing the sample JS code without any tweaks, I encountered an error in relation to Retryable writes. Which aren’t currently supported on DocumentDB. Therefore, I'm proposing adding the Retryable writes option as false on the connection string to minimize configuration effort.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
