### PR TITLE
Update sample_php_documentdb.php

### DIFF
--- a/samples/connect-and-query/sample_php_documentdb.php
+++ b/samples/connect-and-query/sample_php_documentdb.php
@@ -24,7 +24,7 @@ $clusterendpoint = getenv("clusterendpoint");
 //Create a MongoDB client and open connection to Amazon DocumentDB
 //Sample connection string format - mongodb://myusername:mypassword@testcluster.us-east-2.docdb.amazonaws.com:27017
 
-$client = new MongoDB\Client("mongodb://".$username.":".$password."@".$clusterendpoint, array("ssl" => true), array("context" => $ctx));
+$client = new MongoDB\Client("mongodb://".$username.":".$password."@".$clusterendpoint."/"."?"."retryWrites=false", array("ssl" => true), array("context" => $ctx));
 
 $col = $client->sampledb->samplecoll;
 


### PR DESCRIPTION
Proposing updating the connection string with the retrywrites=false option as the code fails on DocumentDB 4.0 without this option.

$client = new MongoDB\Client("mongodb://".$username.":".$password."@".$clusterendpoint."/"."?"."retryWrites=false", array("ssl" => true), array("context" => $ctx));

Error details:
PHP Fatal error:  Uncaught MongoDB\Driver\Exception\BulkWriteException: Retryable writes are not supported in /etc/php/7.2/vendor/mongodb/mongodb/src/Operation/Update.php:228
Stack trace:
#0 /etc/php/7.2/vendor/mongodb/mongodb/src/Operation/Update.php(228): MongoDB\Driver\Server->executeBulkWrite('sampledb.sample...', Object(MongoDB\Driver\BulkWrite), Array)
#1 /etc/php/7.2/vendor/mongodb/mongodb/src/Operation/UpdateOne.php(117): MongoDB\Operation\Update->execute(Object(MongoDB\Driver\Server))
#2 /etc/php/7.2/vendor/mongodb/mongodb/src/Collection.php(1075): MongoDB\Operation\UpdateOne->execute(Object(MongoDB\Driver\Server))
#3 /etc/php/7.2/sample_php_documentdb.php(40): MongoDB\Collection->updateOne(Array, Array)
#4 {main}
  thrown in /etc/php/7.2/vendor/mongodb/mongodb/src/Operation/Update.php on line 228


*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
