### PR TITLE
Update sample_ruby_documentdb.rb

### DIFF
--- a/samples/connect-and-query/sample_ruby_documentdb.rb
+++ b/samples/connect-and-query/sample_ruby_documentdb.rb
@@ -11,7 +11,8 @@ client_options = {
    password: ENV['password'],
    ssl: true,
    ssl_verify: true,
-   ssl_ca_cert: '/home/ubuntu/environment/rds-combined-ca-bundle.pem'
+   ssl_ca_cert: '/home/ubuntu/environment/rds-combined-ca-bundle.pem',
+   retry_writes: false
 }
 
 data = [{ "_id" => 1, "name" => "Tim", "status"=> "active", "level "=> 12, "score" => 202}, { "_id" => 2, "name" => "Justin", "status" => "inactive", "level" => 2, "score" => 9}, { "_id" => 3, "name" => "Beth", "status" => "active", "level" => 7, "score" => 87}, { "_id" => 4, "name" => "Jesse", "status" => "active", "level" => 3, "score" => 27}]


### PR DESCRIPTION
Sample ruby code also fails with the Retrywable writes error as seen below. I have now updated the client connection string with this option and it should work for documentdb 4.0.

/var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/result.rb:343:in `raise_operation_failure': Retryable writes are not supported (301) (on docdb-40-cluster.c1usoxknumgl.eu-west-1.docdb.amazonaws.com:27017, modern retry, attempt 1) (Mongo::Error::OperationFailure)
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/result.rb:311:in `validate!'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:29:in `block (3 levels) in validate_result'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:96:in `add_server_diagnostics'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:28:in `block (2 levels) in validate_result'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:43:in `add_error_labels'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:27:in `block in validate_result'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:82:in `unpin_maybe'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/response_handling.rb:26:in `validate_result'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/write.rb:51:in `block in execute'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/server/connection_pool.rb:590:in `with_connection'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/server.rb:429:in `with_connection'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/operation/shared/write.rb:40:in `execute'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/collection/view/writable.rb:416:in `block (2 levels) in update_one'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/retryable.rb:227:in `write_with_retry'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/collection/view/writable.rb:403:in `block in update_one'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/client.rb:1023:in `with_session'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/collection/view.rb:216:in `with_session'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/collection/view/writable.rb:397:in `update_one'
	from /var/lib/gems/2.3.0/gems/mongo-2.14.0.rc1/lib/mongo/collection.rb:765:in `update_one'
	from sample_ruby_documentdb.rb:36:in `<main>'

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
