### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/lambda-layers/nodejs/action.sh
+++ b/lambda-layers/nodejs/action.sh
@@ -5,7 +5,7 @@
 : "${AWS_DEFAULT_REGION:?Need to set AWS_DEFAULT_REGION non-empty}"
 
 LAYER_NAME=documentdb-nodejs
-RUNTIMES="nodejs10.x nodejs12.x"
+RUNTIMES="nodejs14.x nodejs12.x"
 PACKAGES="mongodb mongoose"
 WORKDIR=/tmp/nodejs
 PEMFILE="https://s3.amazonaws.com/rds-downloads/rds-combined-ca-bundle.pem"


### PR DESCRIPTION
CloudFormation templates in amazon-documentdb-samples have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.