### PR TITLE
Fixed custom rules for deleted resources and simplify instance type rule for 1-instance clusters

### DIFF
--- a/blogs/awsconfig-docdb/lib/amazon-documentdb-aws-config-stack.ts
+++ b/blogs/awsconfig-docdb/lib/amazon-documentdb-aws-config-stack.ts
@@ -149,7 +149,7 @@ export class AmazonDocumentdbAwsConfigStack extends cdk.Stack {
     notificationRule.addTarget(new CloudWatchLogGroup(logGroup));
     notificationRule.addTarget(new SnsTopic(topic));
 
-    // paramater group remediation
+    // parameter group remediation
     // (the IAM role below can be shared among both lambda functions that remediate
     // wrong parameter group and deletion protection disabled as they both perform the
     // same operations and thus require same IAM permissions with current implementation)

--- a/blogs/awsconfig-docdb/lib/functions/cluster-backup-retention-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/cluster-backup-retention-rule/index.js
@@ -74,15 +74,21 @@ async function getConfigurationItem(invokingEvent) {
 // has been deleted and if it has, then the evaluation is unnecessary
 function isApplicable(configurationItem, event) {
   checkDefined(configurationItem, 'configurationItem');
-  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
 
-  if (configurationItem.resourceType !== 'AWS::RDS::DBCluster' || configurationItem.configuration.engine !== 'docdb') {
-    console.log('This is not a DocumentDB Instance');
+  // if eventLeftScope is true the resource to be evaluated has been removed
+  // https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules_example-events.html
+  const eventLeftScope = event.eventLeftScope;
+  if (eventLeftScope) {
     return false;
   }
 
-  const status = configurationItem.configurationItemStatus;
-  const eventLeftScope = event.eventLeftScope;
+  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
+  if (configurationItem.resourceType !== 'AWS::RDS::DBCluster' || configurationItem.configuration.engine !== 'docdb') {
+    console.log('This is not a DocumentDB cluster');
+    return false;
+  }
+
+  const status = configurationItem.configurationItemStatus;  
   return (status === 'OK' || status === 'ResourceDiscovered') && eventLeftScope === false;
 }
 

--- a/blogs/awsconfig-docdb/lib/functions/cluster-backup-retention-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/cluster-backup-retention-rule/index.js
@@ -94,8 +94,6 @@ function isApplicable(configurationItem, event) {
 
 // Evaluates whether the cluster backup retention is greater than a value configured as parameter
 async function evaluateChangeNotificationCompliance(configurationItem, ruleParameters) {
-  console.log('configurationItem', configurationItem);
-
   checkDefined(configurationItem, 'configurationItem');
   checkDefined(configurationItem.configuration, 'configurationItem.configuration');
   checkDefined(configurationItem.configuration.backupRetentionPeriod, 'configurationItem.configuration.backupRetentionPeriod');

--- a/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-remediation/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-remediation/index.js
@@ -9,7 +9,7 @@ exports.handler = async event => {
     const desiredClusterParameterGroup = process.env.DESIRED_CLUSTER_PARAMETER_GROUP;
 
     if (!desiredClusterParameterGroup) {
-      throw new Error('Desired cluster paramater group not found');
+      throw new Error('Desired cluster parameter group not found');
     }
 
     const {detail: {resourceId}} = event;

--- a/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-rule/index.js
@@ -94,8 +94,6 @@ function isApplicable(configurationItem, event) {
 
 // Evaluates whether the cluster parameter group is the one provided to the rule as a parameter
 async function evaluateChangeNotificationCompliance(configurationItem, ruleParameters) {
-  console.log('configurationItem', configurationItem);
-
   checkDefined(configurationItem, 'configurationItem');
   checkDefined(configurationItem.configuration, 'configurationItem.configuration');
   checkDefined(configurationItem.configuration.dbclusterParameterGroup, 'configurationItem.configuration.dbclusterParameterGroup');

--- a/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/cluster-parameter-group-rule/index.js
@@ -74,15 +74,21 @@ async function getConfigurationItem(invokingEvent) {
 // has been deleted and if it has, then the evaluation is unnecessary
 function isApplicable(configurationItem, event) {
   checkDefined(configurationItem, 'configurationItem');
-  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
 
+  // if eventLeftScope is true the resource to be evaluated has been removed
+  // https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules_example-events.html
+  const eventLeftScope = event.eventLeftScope;
+  if (eventLeftScope) {
+    return false;
+  }
+
+  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
   if (configurationItem.resourceType !== 'AWS::RDS::DBCluster' || configurationItem.configuration.engine !== 'docdb') {
-    console.log('This is not a DocumentDB Instance');
+    console.log('This is not a DocumentDB cluster');
     return false;
   }
 
   const status = configurationItem.configurationItemStatus;
-  const eventLeftScope = event.eventLeftScope;
   return (status === 'OK' || status === 'ResourceDiscovered') && eventLeftScope === false;
 }
 

--- a/blogs/awsconfig-docdb/lib/functions/instances-homogeneous-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/instances-homogeneous-rule/index.js
@@ -75,15 +75,21 @@ async function getConfigurationItem(invokingEvent) {
 // has been deleted and if it has, then the evaluation is unnecessary
 function isApplicable(configurationItem, event) {
   checkDefined(configurationItem, 'configurationItem');
-  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
-
-  if (configurationItem.resourceType !== 'AWS::RDS::DBInstance' || configurationItem.configuration.engine !== 'docdb') {
-    console.log('This is not a DocumentDB Instance');
+  
+  // if eventLeftScope is true the resource to be evaluated has been removed
+  // https://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules_example-events.html
+  const eventLeftScope = event.eventLeftScope;
+  if (eventLeftScope) {
     return false;
   }
 
-  const status = configurationItem.configurationItemStatus;
-  const eventLeftScope = event.eventLeftScope;
+  checkDefined(configurationItem.configuration, 'configurationItem.configuration');
+  if (configurationItem.resourceType !== 'AWS::RDS::DBInstance' || configurationItem.configuration.engine !== 'docdb') {
+    console.log('This is not a DocumentDB instance');
+    return false;
+  }
+
+  const status = configurationItem.configurationItemStatus;  
   return (status === 'OK' || status === 'ResourceDiscovered') && eventLeftScope === false;
 }
 

--- a/blogs/awsconfig-docdb/lib/functions/instances-homogeneous-rule/index.js
+++ b/blogs/awsconfig-docdb/lib/functions/instances-homogeneous-rule/index.js
@@ -87,8 +87,12 @@ function isApplicable(configurationItem, event) {
   return (status === 'OK' || status === 'ResourceDiscovered') && eventLeftScope === false;
 }
 
-// Evaluate if all cluster instances belong to the same instance family and size
+// evaluate if all cluster instances belong to the same instance family and size
 async function evaluateChangeNotificationCompliance(configurationItem, dbClusterInstances) {
+  if (dbClusterInstances.length === 1) {
+    return 'COMPLIANT';
+  }
+
   checkDefined(configurationItem, 'configurationItem');
   checkDefined(configurationItem.configuration, 'configurationItem.configuration');
   
@@ -143,13 +147,13 @@ exports.handler = async event => {
     };
     let dbClusterInstances = [];
 
-    // if it is a document cluster, update rule compliance status
-    // for all its instances
+    // only evaluate rule for documentdb clusters
     if (isApplicable(configurationItem, event)) {
       // invoke the compliance checking function
       dbClusterInstances = await getClusterInstances(configurationItem);
       compliance = await evaluateChangeNotificationCompliance(configurationItem, dbClusterInstances);
 
+      // update rule compliance status for all instances
       dbClusterInstances.forEach(i => {
         putEvaluationsRequest.Evaluations.push({
           ComplianceResourceType: configurationItem.resourceType,


### PR DESCRIPTION
*Description of changes:*

- For the one-instance clusters, we don't need retrieve cluster instance data and evaluate if instance types are all the same. We can just return compliant with the subsequent improvement on performance.
- There was a bug for deleted resources that caused to evaluate custom rules for phantom resources (see attached image). It has now been fixed by relying on the _eventLeftScope_ property.
- Further logging improvements