### PR TITLE
Allow EventBridge to interact with the KMS key used for SNS topic encryption

### DIFF
--- a/blogs/awsconfig-docdb/lib/amazon-documentdb-aws-config-stack.ts
+++ b/blogs/awsconfig-docdb/lib/amazon-documentdb-aws-config-stack.ts
@@ -116,9 +116,19 @@ export class AmazonDocumentdbAwsConfigStack extends cdk.Stack {
 
     // remediation
     // sns topic for notifications
+    const key = new Key(this, 'Key');
+    key.addToResourcePolicy(new PolicyStatement({
+      actions: [
+        'kms:GenerateDataKey',
+        'kms:Decrypt'
+      ],
+      principals: [new ServicePrincipal('events.amazonaws.com')],
+      resources: ['*'],
+    }));
+
     const topic = new Topic(this, 'ComplianceNotificationsTopic', {
       displayName: 'Compliance Notifications',
-      masterKey: new Key(this, 'Key')
+      masterKey: key
     });
 
     // cloudwatch log group for debugging purposes


### PR DESCRIPTION
*Description of changes:*

- In a previous PR (https://github.com/aws-samples/amazon-documentdb-samples/pull/7), I added encryption to the Amazon SNS topic used for notifications. However, I forgot that Amazon EventBridge publishes directly to this topic, hence needing access to the AWS KMS key.
