### PR TITLE
Enabling default encryption on Amazon DocumentDb Cluster

### DIFF
--- a/blogs/appsync-docdb/template.yml
+++ b/blogs/appsync-docdb/template.yml
@@ -123,6 +123,7 @@ Resources:
       MasterUserPassword: !Sub "${DocDbpassword}"
       EngineVersion: 4.0.0
       DBSubnetGroupName: !Ref BlogDBSubnetGroup
+      StorageEncrypted : true
       VpcSecurityGroupIds:
       - Fn::GetAtt:
             - BlogDocdbSg


### PR DESCRIPTION
Issue #- https://t.corp.amazon.com/V498355357/

*Description of changes:*
Added       StorageEncrypted : true in the CFT to enable default encryption

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
