### PR TITLE
Adding docdb-scaleOnSchedule.py to Lambda samples

### DIFF
--- a/lambda-samples/samples/README.md
+++ b/lambda-samples/samples/README.md
@@ -70,3 +70,43 @@ Python 3.x
 **Environment variables:**
  - DOCDB_SECRET_NAME: The name of the secret in AWS Secrets Manager containing DocumentDB credentials.
  - THRESHOLD_SECONDS: The number of seconds the operation is running for to be considered long running and stopped
+
+### 4. docdb-scaleOnSchedule.py
+
+**Description:**  
+The `docdb-scaleOnSchedule.py` Lambda function will let you add or remove instances from your cluster. You can use the Eventbridge rule to schedule the addition or deletion of instances. You can [create Eventbridge rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-run-lambda-schedule.html#eb-schedule-create-rule) to schedule how often the Lambda functions to add and delete the instances. 
+
+**Runtime:**  
+Python 3.x
+
+**Dependencies:**
+- Add a lambda layer that contains the logger Python module.
+- Lambda IAM role requires necessary permission to list, add, and delete instances
+```
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "rds:DeleteDBInstance",
+                "rds:CreateDBInstance",
+                "rds:ListTagsForResource",
+                "rds:AddTagsToResource",
+                "rds:DescribeDBClusters"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+```
+- Configure the lambda timeout to a higher value than the default 3 seconds.
+
+**Environment variables:**
+- CLUSTER_IDENTIFIER: This is your Amazon DocumentDB cluster identifier.
+- INSTANCE_CLASS: The instance class of your instance, for example: r6g.large, r5.large, e.t.c.
+- INSTANCE_PROMOTION_TIER: The value that specifies the order in which an Amazon DocumentDB replica instance is promoted to the primary in the cluster after a failure of the existing primary instance. It is recommended to use a value greater than 1 with this script.
+- INSTANCE_NAME_SUFFIX : An instance name suffix to help you identify instances easily. Instances launched by this script would have this suffix followed by a random string. This value should not be greater than 56 characters.
+- INSTANCES_TO_ADD : Number of instances to add to the cluster at a time. 
+- INSTANCES_TO_DELETE: Number of instances to add to the cluster at a time. 
+- Set the Lambda event variable depending on which action to perform (Add or Delete).

--- a/lambda-samples/samples/README.md
+++ b/lambda-samples/samples/README.md
@@ -106,7 +106,7 @@ Python 3.x
 - CLUSTER_IDENTIFIER: This is your Amazon DocumentDB cluster identifier.
 - INSTANCE_CLASS: The instance class of your instance, for example: r6g.large, r5.large, e.t.c.
 - INSTANCE_PROMOTION_TIER: The value that specifies the order in which an Amazon DocumentDB replica instance is promoted to the primary in the cluster after a failure of the existing primary instance. It is recommended to use a value greater than 1 with this script.
-- INSTANCE_NAME_SUFFIX : An instance name suffix to help you identify instances easily. Instances launched by this script would have this suffix followed by a random string. This value should not be greater than 56 characters.
+- INSTANCE_NAME_SUFFIX : An instance name suffix to help you identify instances easily. Instances launched by this script would have this suffix followed by a random string. This value should not be greater than 56 characters and should be alphanumeric.
 - INSTANCES_TO_ADD : Number of instances to add to the cluster at a time. 
 - INSTANCES_TO_DELETE: Number of instances to add to the cluster at a time. 
 - Set the Lambda event variable depending on which action to perform (Add or Delete).

--- a/lambda-samples/samples/README.md
+++ b/lambda-samples/samples/README.md
@@ -80,7 +80,6 @@ The `docdb-scaleOnSchedule.py` Lambda function will let you add or remove instan
 Python 3.x
 
 **Dependencies:**
-- Add a lambda layer that contains the logger Python module.
 - Lambda IAM role requires necessary permission to list, add, and delete instances
 ```
 {
@@ -100,13 +99,11 @@ Python 3.x
     ]
 }
 ```
-- Configure the lambda timeout to a higher value than the default 3 seconds.
+- Configure the lambda timeout to 10 seconds or more from the default 3 seconds.
 
 **Environment variables:**
 - CLUSTER_IDENTIFIER: This is your Amazon DocumentDB cluster identifier.
 - INSTANCE_CLASS: The instance class of your instance, for example: r6g.large, r5.large, e.t.c.
-- INSTANCE_PROMOTION_TIER: The value that specifies the order in which an Amazon DocumentDB replica instance is promoted to the primary in the cluster after a failure of the existing primary instance. It is recommended to use a value greater than 1 with this script.
-- INSTANCE_NAME_SUFFIX : An instance name suffix to help you identify instances easily. Instances launched by this script would have this suffix followed by a random string. This value should not be greater than 56 characters and should be alphanumeric.
 - INSTANCES_TO_ADD : Number of instances to add to the cluster at a time. 
 - INSTANCES_TO_DELETE: Number of instances to add to the cluster at a time. 
 - Set the Lambda event variable depending on which action to perform (Add or Delete).

--- a/lambda-samples/samples/docdb-scaleOnSchedule.py
+++ b/lambda-samples/samples/docdb-scaleOnSchedule.py
@@ -1,92 +1,158 @@
-import json
 import os
 import boto3
+import string
 import random
 import logging
-import string
-import logger
 import sys
 
-#Set up the logger
+# Set up the logger
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-clusterIdentifier = os.environ['CLUSTER_IDENTIFIER']
-instanceSuffix = os.environ['INSTANCE_NAME_SUFFIX']
-instanceClass = os.environ['INSTANCE_CLASS']
-instancePromotionTier = int(os.environ['INSTANCE_PROMOTION_TIER'])
-numInstancesToAdd = int(os.environ['INSTANCES_TO_ADD'])
-numInstancesToDel = int(os.environ['INSTANCES_TO_DELETE'])
+clusterIdentifier = (os.environ["CLUSTER_IDENTIFIER"]).strip()
+instanceClass = (os.environ["INSTANCE_CLASS"]).strip()
+numInstancesToAdd = int(os.environ["INSTANCES_TO_ADD"])
+numInstancesToDel = int(os.environ["INSTANCES_TO_DELETE"])
 
-client = boto3.client('docdb')
+instancePromotionTier = 15
+instanceSuffix = "tempinstance"
+
+supportedInstanceClasses = [
+    "db.r6g.large",
+    "db.r6g.xlarge",
+    "db.r6g.2xlarge",
+    "db.r6g.4xlarge",
+    "db.r6g.8xlarge",
+    "db.r6g.12xlarge",
+    "db.r6g.16xlarge",
+    "db.r5.large",
+    "db.r5.xlarge",
+    "db.r5.2xlarge",
+    "db.r5.4xlarge",
+    "db.r5.8xlarge",
+    "db.r5.12xlarge",
+    "db.r5.16xlarge	",
+    "db.r5.24xlarge",
+    "db.t3.medium",
+    "db.t4g.medium",
+]
+
+
+client = boto3.client("docdb")
+
 
 def lambda_handler(event, context):
+
     ## Set the following Lambda event variable depending on which action the function should take
-    # Action = Add | Delete  
-    
-    if event['Action'] == 'Add':
+    # Action = Add | Delete
+
+    if event["Action"] == "Add":
         actionResponse = add_instances()
-    if event['Action'] == 'Delete':
+    if event["Action"] == "Delete":
         actionResponse = delete_instances()
+
     logger.info(actionResponse)
+
 
 def add_instances():
 
     createResponse = {}
-    clusterInfo = client.describe_db_instances(Filters=[{'Name':'db-cluster-id','Values':[clusterIdentifier]}])
-    listOfInstances=clusterInfo['DBInstances']
+    clusterInfo = client.describe_db_instances(
+        Filters=[{"Name": "db-cluster-id", "Values": [clusterIdentifier]}]
+    )
+    listOfInstances = clusterInfo["DBInstances"]
     currInstanceCount = len(listOfInstances)
-    
-    if((currInstanceCount + numInstancesToAdd ) <= 16 ):
-        
+
+    if (
+        currInstanceCount + numInstancesToAdd
+    ) <= 16 and instanceClass in supportedInstanceClasses:
+
         for inst in range(numInstancesToAdd):
-            randString = ''.join(random.choices(string.ascii_lowercase, k=6))
-            instanceIdentifier = instanceSuffix +'-'+ randString
-        
-            try: 
+            randString = "".join(random.choices(string.ascii_lowercase, k=6))
+            instanceIdentifier = instanceSuffix + "-" + randString
+
+            try:
                 instanceCreateResponse = client.create_db_instance(
-                DBClusterIdentifier = clusterIdentifier,
-                DBInstanceIdentifier = instanceIdentifier,
-                DBInstanceClass = instanceClass,
-                Tags = [{'Key':'scheduledTemporaryInstance', 'Value':'Yes'}],
-                Engine = 'docdb',
-                PromotionTier = instancePromotionTier )
-                
-                createResponse[instanceIdentifier] = instanceCreateResponse['ResponseMetadata']
-                
+                    DBClusterIdentifier=clusterIdentifier,
+                    DBInstanceIdentifier=instanceIdentifier,
+                    DBInstanceClass=instanceClass,
+                    Tags=[{"Key": "scheduledTemporaryInstance", "Value": "Yes"}],
+                    Engine="docdb",
+                    PromotionTier=instancePromotionTier,
+                )
+
+                createResponse[instanceIdentifier] = instanceCreateResponse[
+                    "ResponseMetadata"
+                ]
+
             except:
-                logger.error("Encountered problem while creating instance. Error message is ", sys.exc_info()[0], sys.exc_info()[1])
-             
-    else:
-            logger.info( "Cannot add more instances to the cluster " + clusterIdentifier + " already has  " + str(currInstanceCount) + " instances. " + "Adding " + str(numInstancesToAdd) + " instaces exeeds the maximum number of allowed instances (16) in a cluster")
+                logger.error(
+                    "Encountered problem while creating instance. Error message is %s %s",
+                    sys.exc_info()[0],
+                    sys.exc_info()[1],
+                )
+
+    elif (currInstanceCount + numInstancesToAdd) > 16:
+        logger.info(
+            "Cannot add more instances to the cluster "
+            + clusterIdentifier
+            + " already has  "
+            + str(currInstanceCount)
+            + " instances. "
+            + "Adding "
+            + str(numInstancesToAdd)
+            + " instances exceeds the maximum number of allowed instances (16) in a cluster"
+        )
+    elif instanceClass not in supportedInstanceClasses:
+        logger.info(instanceClass + " is not a supported instance class")
+
     return createResponse
 
+
 def delete_instances():
-    
-    delResponse =  {}
-    instancesDeleted={}
+
+    delResponse = {}
+    instancesDeleted = {}
     instListToDelete = {}
 
-    clusterInfo = client.describe_db_clusters(Filters=[{'Name':'db-cluster-id','Values':[clusterIdentifier]}])['DBClusters']
-    
+    clusterInfo = client.describe_db_clusters(
+        Filters=[{"Name": "db-cluster-id", "Values": [clusterIdentifier]}]
+    )["DBClusters"]
+
     for clusterMembers in clusterInfo:
-        instanceLists = clusterMembers['DBClusterMembers']
+        instanceLists = clusterMembers["DBClusterMembers"]
         for instance in instanceLists:
-            instanceDetails=client.describe_db_instances(DBInstanceIdentifier=instance['DBInstanceIdentifier'])['DBInstances']
+            instanceDetails = client.describe_db_instances(
+                DBInstanceIdentifier=instance["DBInstanceIdentifier"]
+            )["DBInstances"]
             for instArn in instanceDetails:
-                tags = client.list_tags_for_resource(ResourceName=instArn['DBInstanceArn'])['TagList']
-                
+                tags = client.list_tags_for_resource(
+                    ResourceName=instArn["DBInstanceArn"]
+                )["TagList"]
+
                 for tag in tags:
-                    if (tag['Key'] == 'scheduledTemporaryInstance' and tag['Value'] == 'Yes') and instance['IsClusterWriter'] == False and instance['DBInstanceIdentifier'].startswith(instanceSuffix) and instArn['DBInstanceStatus'].lower() == 'available' :
-                       
-                        instListToDelete[instance['DBInstanceIdentifier']] = instArn['DBInstanceArn']
-    
-    if(len(instListToDelete) >= numInstancesToDel):
+                    if (
+                        (
+                            tag["Key"] == "scheduledTemporaryInstance"
+                            and tag["Value"] == "Yes"
+                        )
+                        and instance["IsClusterWriter"] == False
+                        and instance["DBInstanceIdentifier"].startswith(instanceSuffix)
+                        and instArn["DBInstanceStatus"].lower() == "available"
+                    ):
+
+                        instListToDelete[instance["DBInstanceIdentifier"]] = instArn[
+                            "DBInstanceArn"
+                        ]
+
+    if len(instListToDelete) >= numInstancesToDel:
         for instanceIdentifier in instListToDelete:
-            delResponse = client.delete_db_instance(DBInstanceIdentifier = instanceIdentifier)
-            instancesDeleted[instanceIdentifier] = delResponse['ResponseMetadata']
-            if(len(instancesDeleted) >= numInstancesToDel):
+            delResponse = client.delete_db_instance(
+                DBInstanceIdentifier=instanceIdentifier
+            )
+            instancesDeleted[instanceIdentifier] = delResponse["ResponseMetadata"]
+            if len(instancesDeleted) >= numInstancesToDel:
                 return instancesDeleted
     else:
-        return ("No Amazon DocumentDB instances found matching the delete criteria")
+        return "No Amazon DocumentDB instances found matching the delete criteria"

--- a/lambda-samples/samples/docdb-scaleOnSchedule.py
+++ b/lambda-samples/samples/docdb-scaleOnSchedule.py
@@ -1,0 +1,92 @@
+import json
+import os
+import boto3
+import random
+import logging
+import string
+import logger
+import sys
+
+#Set up the logger
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+clusterIdentifier = os.environ['CLUSTER_IDENTIFIER']
+instanceSuffix = os.environ['INSTANCE_NAME_SUFFIX']
+instanceClass = os.environ['INSTANCE_CLASS']
+instancePromotionTier = int(os.environ['INSTANCE_PROMOTION_TIER'])
+numInstancesToAdd = int(os.environ['INSTANCES_TO_ADD'])
+numInstancesToDel = int(os.environ['INSTANCES_TO_DELETE'])
+
+client = boto3.client('docdb')
+
+def lambda_handler(event, context):
+    ## Set the following Lambda event variable depending on which action the function should take
+    # Action = Add | Delete  
+    
+    if event['Action'] == 'Add':
+        actionResponse = add_instances()
+    if event['Action'] == 'Delete':
+        actionResponse = delete_instances()
+    logger.info(actionResponse)
+
+def add_instances():
+
+    createResponse = {}
+    clusterInfo = client.describe_db_instances(Filters=[{'Name':'db-cluster-id','Values':[clusterIdentifier]}])
+    listOfInstances=clusterInfo['DBInstances']
+    currInstanceCount = len(listOfInstances)
+    
+    if((currInstanceCount + numInstancesToAdd ) <= 16 ):
+        
+        for inst in range(numInstancesToAdd):
+            randString = ''.join(random.choices(string.ascii_lowercase, k=6))
+            instanceIdentifier = instanceSuffix +'-'+ randString
+        
+            try: 
+                instanceCreateResponse = client.create_db_instance(
+                DBClusterIdentifier = clusterIdentifier,
+                DBInstanceIdentifier = instanceIdentifier,
+                DBInstanceClass = instanceClass,
+                Tags = [{'Key':'scheduledTemporaryInstance', 'Value':'Yes'}],
+                Engine = 'docdb',
+                PromotionTier = instancePromotionTier )
+                
+                createResponse[instanceIdentifier] = instanceCreateResponse['ResponseMetadata']
+                
+            except:
+                logger.error("Encountered problem while creating instance. Error message is ", sys.exc_info()[0], sys.exc_info()[1])
+             
+    else:
+            logger.info( "Cannot add more instances to the cluster " + clusterIdentifier + " already has  " + str(currInstanceCount) + " instances. " + "Adding " + str(numInstancesToAdd) + " instaces exeeds the maximum number of allowed instances (16) in a cluster")
+    return createResponse
+
+def delete_instances():
+    
+    delResponse =  {}
+    instancesDeleted={}
+    instListToDelete = {}
+
+    clusterInfo = client.describe_db_clusters(Filters=[{'Name':'db-cluster-id','Values':[clusterIdentifier]}])['DBClusters']
+    
+    for clusterMembers in clusterInfo:
+        instanceLists = clusterMembers['DBClusterMembers']
+        for instance in instanceLists:
+            instanceDetails=client.describe_db_instances(DBInstanceIdentifier=instance['DBInstanceIdentifier'])['DBInstances']
+            for instArn in instanceDetails:
+                tags = client.list_tags_for_resource(ResourceName=instArn['DBInstanceArn'])['TagList']
+                
+                for tag in tags:
+                    if (tag['Key'] == 'scheduledTemporaryInstance' and tag['Value'] == 'Yes') and instance['IsClusterWriter'] == False and instance['DBInstanceIdentifier'].startswith(instanceSuffix) and instArn['DBInstanceStatus'].lower() == 'available' :
+                       
+                        instListToDelete[instance['DBInstanceIdentifier']] = instArn['DBInstanceArn']
+    
+    if(len(instListToDelete) >= numInstancesToDel):
+        for instanceIdentifier in instListToDelete:
+            delResponse = client.delete_db_instance(DBInstanceIdentifier = instanceIdentifier)
+            instancesDeleted[instanceIdentifier] = delResponse['ResponseMetadata']
+            if(len(instancesDeleted) >= numInstancesToDel):
+                return instancesDeleted
+    else:
+        return ("No Amazon DocumentDB instances found matching the delete criteria")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added docdb-scaleOnSchedule.py. Using this Lambda function, users can add or remove instances from their cluster. Users have to create two Eventbridge rules, one to schedule the addition and the other to delete instances.
Updated README to add a section for docdb-scaleOnSchedule.py

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
