### PR TITLE
New code sample - manage DocumentDB users with Terraform

### DIFF
--- a/samples/terraform_user_management/README.md
+++ b/samples/terraform_user_management/README.md
@@ -1,0 +1,138 @@
+# Amazon DocumentDB (with MongoDB compatibility) User Management with Terraform
+
+This is an example of how to use the [AWS Provider](https://registry.terraform.io/providers/hashicorp/aws/latest/docs) in Terraform, along with [AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), to manage users in Amazon DocumentDB.
+
+## Features
+
+- Create and manage Amazon DocumentDB users with specific roles and permission
+- Automatic user deletion when resources are destroyed
+- Support for multiple database roles per user
+
+## Prerequisites
+
+- [AWS credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration) configured
+- Terraform v0.13+ installed
+- `mongosh` client installed in the environment where Terraform runs (this is validated)
+- Existing Amazon DocumentDB cluster
+- [Amazon DocumentDB primary user credentials](https://docs.aws.amazon.com/documentdb/latest/developerguide/docdb-secrets-manager.html) managed in AWS Secrets Manager
+- Executable permission set for `scripts/*.sh`
+
+## Usage
+
+```hcl
+module "docdb_readonly_user" {
+  source = "path/to/module"
+  
+  region = "your-AWS-region"
+  cluster_endpoint = "your-docdb-cluster.region.docdb.amazonaws.com"
+  admin_secret_arn = "arn:aws:secretsmanager:region:account:secret:admin-credentials"
+  
+  username = "readonlyuser"
+  roles = [
+    {
+      role = "read"
+      db   = "myapp"
+    }
+  ]
+}
+```
+
+## Input Variables
+
+| Name | Description | Type | Required | Default |
+|------|-------------|------|----------|---------|
+| `region` | AWS region where you resources re deployed | `string` | Yes | `us-east-1` |
+| `cluster_endpoint` | Amazon DocumentDB cluster endpoint (hostname without protocol or port) | `string` | Yes | - |
+| `admin_secret_arn` | AWS Secrets Manager ARN containing master credentials | `string` | Yes | - |
+| `username` | Username to manage (3-63 chars, must start with letter, alphanumeric with underscores) | `string` | Yes | - |
+| `roles` | List of roles for the user | `list(object)` | Yes | - |
+| `cluster_port` | Amazon DocumentDB port | `string` | No | `"27017"` |
+
+### Role Format
+
+Each role in the `roles` list should have the following format:
+
+```hcl
+{
+  role = "readWrite"  # The role name (e.g., read, readWrite, dbAdmin)
+  db   = "myapp"      # The database name to apply the role to
+}
+```
+
+## Additional Details
+
+### Admin Secret Format
+The admin secret in AWS Secrets Manager should have the following format:
+```json
+{
+  "username": "admin",
+  "password": "your-admin-password"
+}
+```
+
+### User Management
+The module automatically:
+1. Creates a new AWS Secrets Manager secret named `${username}-docdb-credentials`
+2. Generates a secure random password for the user
+3. Stores the username and password in the secret
+
+The user secret will have the following format:
+```json
+{
+  "username": "your-username",
+  "password": "auto-generated-secure-password"
+}
+```
+
+## Examples
+
+### Read-Only User
+```hcl
+module "docdb_readonly_user" {
+  source = "./users"
+  
+  region = "your-AWS-region"
+  cluster_endpoint = "your-docdb-cluster.region.docdb.amazonaws.com"
+  admin_secret_arn = "arn:aws:secretsmanager:region:account:secret:admin-credentials"
+  
+  username = "readonlyuser"
+  roles = [
+    {
+      role = "read"
+      db   = "myapp"
+    }
+  ]
+}
+```
+
+### Power User with Multiple Roles
+```hcl
+module "docdb_admin_user" {
+  source = "./users"
+  
+  region = "your-AWS-region"
+  cluster_endpoint = "your-docdb-cluster.region.docdb.amazonaws.com"
+  admin_secret_arn = "arn:aws:secretsmanager:region:account:secret:admin-credentials"
+  
+  username = "adminuser"
+  roles = [
+    {
+      role = "readWrite"
+      db   = "myapp1"
+    },
+    {
+      role = "dbAdmin"
+      db   = "myapp2"
+    }
+  ]
+}
+```
+
+## Notes
+
+- The module uses the `mongosh` client to interact with Amazon DocumentDB
+- Currently only supports clusters with [SSL/TLS](https://docs.aws.amazon.com/documentdb/latest/developerguide/security.encryption.ssl.html) enabled (default configuration)
+- Automatically downloads the required certificate bundle (`global-bundle.pem`)
+- This relies on AWS Secret Manager to handle password updates and rotation (see the [AWS Secrets Manager Developer Guide](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotating-secrets.html) for more details)
+- Changes to roles will trigger user updates
+- Username validation ensures compliance with [Amazon DocumentDB naming requirements](https://docs.aws.amazon.com/documentdb/latest/developerguide/limits.html#limits-naming_constraints)

--- a/samples/terraform_user_management/main.tf
+++ b/samples/terraform_user_management/main.tf
@@ -1,0 +1,121 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+# Retrieve primary user credentials from AWS Secrets Manager
+data "aws_secretsmanager_secret_version" "primary" {
+  secret_id = var.admin_secret_arn
+}
+
+# Saved user secret name
+resource "aws_secretsmanager_secret" "user_secret" {
+  name = "${var.username}-docdb-credentials"
+}
+
+# Create complex password
+resource "random_password" "initial_password" {
+  length           = 32
+  special         = true
+  lower           = true
+  upper           = true
+  numeric         = true
+  min_lower       = 1
+  min_upper       = 1
+  min_numeric     = 1
+  min_special     = 1
+  override_special = "!#$%&*()-_=+[]{}<>:?"  
+}
+
+resource "aws_secretsmanager_secret_version" "user_credentials" {
+  secret_id = aws_secretsmanager_secret.user_secret.id
+  secret_string = jsonencode({
+    username = var.username
+    password = random_password.initial_password.result
+  })
+}
+
+locals {
+  # Parse credentials from Secrets Manager
+  primary_credentials = jsondecode(data.aws_secretsmanager_secret_version.primary.secret_string)
+  primary_username   = local.primary_credentials["username"]
+  primary_password   = local.primary_credentials["password"]
+}
+
+# Call upon scripts to create, update role, and delete users
+resource "null_resource" "manage_user" {
+  triggers = {
+    username       = var.username
+    docdb_user     = local.primary_username
+    docdb_password = local.primary_password
+    docdb_host     = var.cluster_endpoint
+    docdb_port     = var.cluster_port
+    roles_hash     = sha256(jsonencode(var.roles))
+  }
+
+  depends_on = [null_resource.download_cert]
+
+  # Create user or update their role
+  provisioner "local-exec" {
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      DOCDB_USER     = local.primary_username
+      DOCDB_PASSWORD = local.primary_password
+      DOCDB_HOST     = var.cluster_endpoint
+      DOCDB_PORT     = var.cluster_port
+      USERNAME       = var.username
+      USER_PASSWORD  = random_password.initial_password.result
+      ROLES          = jsonencode(var.roles)
+      ACTION         = "create"
+      OPERATION_ID   = uuid()
+    }
+    command = file("${path.module}/scripts/manage_docdb_user.sh")
+  }
+
+  # Delete user on destroy
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["/bin/bash", "-c"]
+    environment = {
+      DOCDB_USER     = self.triggers.docdb_user
+      DOCDB_PASSWORD = self.triggers.docdb_password
+      DOCDB_HOST     = self.triggers.docdb_host
+      DOCDB_PORT     = self.triggers.docdb_port
+      USERNAME       = self.triggers.username
+      ACTION         = "delete"
+      OPERATION_ID   = uuid()
+    }
+    command = file("${path.module}/scripts/manage_docdb_user.sh")
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# Download DocumentDB TLS pem
+resource "null_resource" "download_cert" {
+  provisioner "local-exec" {
+    command = file("${path.module}/scripts/download_cert.sh")
+  }
+}
+
+# Output information about the user
+output "user_info" {
+  description = "Information about the Amazon DocumentDB user"
+  value = {
+    username    = var.username
+    roles       = var.roles
+    endpoint    = var.cluster_endpoint
+    created_at  = timestamp()
+  }
+  sensitive = true
+}

--- a/samples/terraform_user_management/scripts/download_cert.sh
+++ b/samples/terraform_user_management/scripts/download_cert.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -e
+
+# Script: download_cert.sh
+# Downloads the Amazon DocumentDB certificate bundle (global-bundle.pem)
+# Ensure script is executable:
+# chmod 755 downloadcert.sh
+
+log() {
+  local level="INFO"
+  if [ "$#" -gt 1 ]; then
+    level="$1"
+    shift
+  fi
+  echo "[$(date +'%Y-%m-%d %H:%M:%S')] [${level}] $1"
+}
+
+error_exit() {
+  log "ERROR" "$1"
+  exit 1
+}
+
+log "Downloading Amazon DocumentDB certificate..."
+
+# Check if curl is installed
+command -v curl >/dev/null 2>&1 || error_exit "curl is required but not installed"
+
+CERT_URL="https://truststore.pki.rds.amazonaws.com/global/global-bundle.pem"
+CERT_FILE="global-bundle.pem"
+
+MAX_RETRIES=3
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  if curl -s -f -o "${CERT_FILE}" "${CERT_URL}"; then
+    break
+  else
+    RETRY_COUNT=$((RETRY_COUNT + 1))
+    if [ $RETRY_COUNT -lt $MAX_RETRIES ]; then
+      log "WARN" "Download attempt ${RETRY_COUNT} failed. Retrying in 5 seconds..."
+      sleep 5
+    else
+      error_exit "Failed to download certificate after ${MAX_RETRIES} attempts"
+    fi
+  fi
+done
+
+# Verify the certificate was downloaded correctly
+if [ ! -s "${CERT_FILE}" ]; then
+  error_exit "Downloaded certificate file is empty"
+fi
+
+if ! grep -q "BEGIN CERTIFICATE" "${CERT_FILE}"; then
+  error_exit "Downloaded file does not appear to be a valid certificate"
+fi
+
+# Set appropriate permissions
+chmod 644 "${CERT_FILE}"
+
+log "Certificate bundle downloaded and verified"

--- a/samples/terraform_user_management/scripts/manage_docdb_user.sh
+++ b/samples/terraform_user_management/scripts/manage_docdb_user.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+set -e
+
+# Script: manage_docdb_user.sh
+# Manages DocumentDB users (create/delete) with proper role management
+# Required environment variables:
+#   DOCDB_HOST - DocumentDB cluster endpoint
+#   DOCDB_PORT - DocumentDB port (usually 27017)
+#   DOCDB_USER - Admin username
+#   DOCDB_PASSWORD - Admin password
+#   USERNAME - User to create/delete
+#   ACTION - Operation to perform (create/delete)
+#   USER_PASSWORD - Password for new user (required for create)
+#   ROLES - JSON array of roles (required for create)
+#
+# Ensure script is executable:
+# chmod 755 manage_docdb_user.sh
+
+# Define log file location with secure permissions
+LOG_DIR="/tmp/docdb_user_management"
+LOG_FILE="${LOG_DIR}/user_operations.log"
+OPERATION_ID=$(uuidgen || date +%s)
+
+setup_logging() {
+  mkdir -p "${LOG_DIR}"
+  touch "${LOG_FILE}"
+  chmod 600 "${LOG_FILE}"
+  chmod 700 "${LOG_DIR}"
+}
+
+log() {
+  local level="INFO"
+  if [ "$#" -gt 1 ]; then
+    level="$1"
+    shift
+  fi
+  local timestamp=$(date +'%Y-%m-%d %H:%M:%S')
+  local message="[${timestamp}] [${level}] [OP:${OPERATION_ID}] $1"
+  
+  echo "${message}"
+  echo "${message}" >> "${LOG_FILE}"
+}
+
+setup_logging
+
+error_exit() {
+  local message="$1"
+  local exit_code=1
+  
+  if [ "$#" -gt 1 ]; then
+    exit_code="$2"
+  fi
+  
+  log "ERROR" "${message}"
+  exit "${exit_code}"
+}
+
+validate_env() {
+  local required_vars=("DOCDB_HOST" "DOCDB_PORT" "DOCDB_USER" "USERNAME" "ACTION")
+  
+  for var in "${required_vars[@]}"; do
+    if [ -z "${!var}" ]; then
+      error_exit "Required environment variable ${var} is not set" 2
+    fi
+  done
+  
+  if [ "${ACTION}" == "create" ] && [ -z "${USER_PASSWORD}" ]; then
+    error_exit "USER_PASSWORD is required for create operations" 3
+  fi
+  
+  if [ "${ACTION}" == "create" ] && [ -z "${ROLES}" ]; then
+    error_exit "ROLES are required for create operations" 4
+  fi
+  
+  log "Environment validation completed"
+}
+
+check_prerequisites() {
+  log "Checking prerequisites..."
+  
+  command -v mongosh >/dev/null 2>&1 || error_exit "mongosh is required but not installed" 5
+  
+  if [ ! -f global-bundle.pem ]; then
+    error_exit "SSL certificate not found" 6
+  fi
+  
+  if ! grep -q "BEGIN CERTIFICATE" global-bundle.pem; then
+    error_exit "Invalid SSL certificate" 7
+  fi
+  
+  log "Prerequisites verified"
+}
+
+test_connection() {
+  local masked_host="${DOCDB_HOST%%.*}*****"
+  log "Testing database connection to ${masked_host}:${DOCDB_PORT}..."
+  
+  if ! mongosh --host $DOCDB_HOST:$DOCDB_PORT \
+    --username $DOCDB_USER \
+    --password $DOCDB_PASSWORD \
+    --tls \
+    --tlsCAFile global-bundle.pem \
+    --authenticationMechanism SCRAM-SHA-1 \
+    --eval "db.adminCommand('ping')" &>/dev/null; then
+    error_exit "Database connection failed" 8
+  fi
+  
+  log "Database connection successful"
+}
+
+check_user_exists() {
+  local log_tmp="/tmp/user_check_$$.log"
+  
+  log "Verifying user existence..." >> "${log_tmp}"
+  
+  local result=$(mongosh --host $DOCDB_HOST:$DOCDB_PORT \
+    --username $DOCDB_USER \
+    --password $DOCDB_PASSWORD \
+    --tls \
+    --tlsCAFile global-bundle.pem \
+    --authenticationMechanism SCRAM-SHA-1 \
+    --quiet \
+    --eval 'try { 
+      const user = db.getSiblingDB("admin").getUser("'"${USERNAME}"'");
+      if (user && user.user === "'"${USERNAME}"'") {
+        print("true");
+      } else {
+        print("false");
+      }
+    } catch(e) { 
+      print("false");
+    }' 2>/dev/null || echo "false")
+  
+  cat "${log_tmp}" >> "${LOG_FILE}"
+  rm -f "${log_tmp}"
+  
+  echo "${result}" | tr -d '[:space:]'
+}
+
+manage_user() {
+  local user_exists=$(check_user_exists)
+  
+  if [ "${user_exists}" = "true" ]; then
+    log "Updating existing user roles..."
+    
+    mongosh --host $DOCDB_HOST:$DOCDB_PORT \
+      --username $DOCDB_USER \
+      --password $DOCDB_PASSWORD \
+      --tls \
+      --tlsCAFile global-bundle.pem \
+      --authenticationMechanism SCRAM-SHA-1 \
+      --eval 'db.getSiblingDB("admin").updateUser("'"${USERNAME}"'", {
+        roles: '"${ROLES}"'
+      })'
+      
+    log "Role update completed successfully"
+  else
+    log "Creating new user..."
+    mongosh --host $DOCDB_HOST:$DOCDB_PORT \
+      --username $DOCDB_USER \
+      --password $DOCDB_PASSWORD \
+      --tls \
+      --tlsCAFile global-bundle.pem \
+      --authenticationMechanism SCRAM-SHA-1 \
+      --eval 'db.getSiblingDB("admin").createUser({
+        user: "'"${USERNAME}"'",
+        pwd: "'"${USER_PASSWORD}"'",
+        roles: '"${ROLES}"'
+      })'
+      
+    log "User creation completed successfully"
+  fi
+}
+
+delete_user() {
+  log "Initiating user deletion process..."
+  
+  local user_exists=$(check_user_exists)
+  
+  if [ "${user_exists}" = "true" ]; then
+    log "Executing deletion..."
+    
+    local delete_result=$(mongosh --host $DOCDB_HOST:$DOCDB_PORT \
+      --username $DOCDB_USER \
+      --password $DOCDB_PASSWORD \
+      --tls \
+      --tlsCAFile global-bundle.pem \
+      --authenticationMechanism SCRAM-SHA-1 \
+      --quiet \
+      --eval 'try { 
+        const result = db.getSiblingDB("admin").dropUser("'"${USERNAME}"'");
+        if (result.ok === 1) {
+          print("success");
+        } else {
+          print("failed: " + JSON.stringify(result));
+          quit(1);
+        }
+      } catch(e) { 
+        print("error: " + e.message); 
+        quit(1); 
+      }' 2>/dev/null)
+    
+    if [ "${delete_result}" != "success" ]; then
+      error_exit "Failed to delete user" 11
+    fi
+    
+    if [ "$(check_user_exists)" = "true" ]; then
+      error_exit "User still exists after deletion attempt" 11
+    fi
+    
+    log "Deletion completed successfully"
+  else
+    log "WARN" "No deletion needed - user does not exist"
+  fi
+}
+
+main() {
+  log "Starting operation ${OPERATION_ID}"
+  validate_env
+  check_prerequisites
+  test_connection
+  
+  case "${ACTION}" in
+    create)
+      manage_user
+      ;;
+    delete)
+      delete_user
+      ;;
+    *)
+      error_exit "Invalid ACTION specified" 12
+      ;;
+  esac
+  
+  log "Operation ${OPERATION_ID} completed successfully"
+}
+
+main

--- a/samples/terraform_user_management/terraform.tfvars
+++ b/samples/terraform_user_management/terraform.tfvars
@@ -1,0 +1,6 @@
+region            = "your-aws-region"
+cluster_endpoint  = "your-docdb-cluster-endpoint"
+cluster_port      = "your-docdb-port"
+admin_secret_arn  = "your-admin-secret-arn"
+username          = "desired-username"
+roles             = ["your-desired-roles"]

--- a/samples/terraform_user_management/variables.tf
+++ b/samples/terraform_user_management/variables.tf
@@ -1,0 +1,61 @@
+# users/variables.tf
+variable "region" {
+  type        = string
+  description = "AWS region"
+  default     = "us-east-1"
+}
+
+variable "cluster_endpoint" {
+  type = string
+  description = "DocumentDB cluster endpoint. Example - sample-cluster.cluster-sfcrlcjcoroz.us-east-1.docdb.amazonaws.com"
+}
+
+variable "cluster_port" {
+  type = string
+  description = "DocumentDB port (default 27017)"
+  default = "27017"
+}
+
+variable "admin_secret_arn" {
+  description = "The ARN of the secret containing primary user's credentials"
+  type        = string
+  
+  validation {
+    condition     = can(regex("^arn:aws:secretsmanager:", var.admin_secret_arn))
+    error_message = "The admin_secret_arn must be a valid Secret Manager ARN."
+  }
+}
+
+variable "username" {
+  type = string
+  description = "Username to manage"
+  validation {
+    condition     = length(var.username) >= 3 && length(var.username) <= 63 && can(regex("^[a-zA-Z][a-zA-Z0-9_]*$", var.username))
+    error_message = "Username must be 3-63 characters, start with a letter, and contain only letters, numbers, and underscores."
+  }
+}
+
+variable "roles" {
+  type = list(object({
+    role = string
+    db   = string
+  }))
+  description = <<-EOT
+    List of role objects containing role and database assignments.
+    Example:
+      roles = [
+        {
+          role = "read"
+          db   = "sample-database-1"
+        },
+        {
+          role = "readWrite"
+          db   = "database2"
+        }
+      ]
+  EOT
+  validation {
+    condition     = length(var.roles) > 0
+    error_message = "At least one role must be specified."
+  }
+}


### PR DESCRIPTION
Example of how to use the AWS Provider in Terraform, along with AWS Secrets Manager, to manage users in Amazon DocumentDB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
